### PR TITLE
Add __main__.py

### DIFF
--- a/src/pyright_polite/__main__.py
+++ b/src/pyright_polite/__main__.py
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: Copyright © 2024 Felix Fourcolor <felix.fourcolor@gmail.com>
+# SPDX-License-Identifier: MIT
+
+"""Alternative entrypoint."""
+
+from .main import main
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
So that the program can be invoked as `python -m pyright_polite`. You can do it with pyright (`python -m pyright`), so I thought why not.